### PR TITLE
Update to Apache Groovy 4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <groovy.version>3.0.8</groovy.version>
+    <groovy.version>4.0.6</groovy.version>
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>
     <guava.version>31.1-jre</guava.version>
@@ -41,6 +41,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy-bom</artifactId>
+        <version>${groovy.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -75,36 +83,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy</artifactId>
-        <version>${groovy.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-json</artifactId>
-        <version>${groovy.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-xml</artifactId>
-        <version>${groovy.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-yaml</artifactId>
-        <version>${groovy.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-ant</artifactId>
-        <version>${groovy.version}</version>
       </dependency>
 
       <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -62,7 +62,7 @@
 <!--    </dependency>-->
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-ant</artifactId>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.buildsupport</groupId>
     <artifactId>public-parent</artifactId>
-    <version>33</version>
+    <version>36</version>
     <relativePath/>
   </parent>
 
@@ -115,23 +115,33 @@
         </executions>
       </plugin>
 
+      <!--
+      FIXME: unfortunately; the latest builds of the compiler and batch adapter are not published to Maven Central
+
+      FIXME: they are only in:
+      FIXME:    https://groovy.jfrog.io/artifactory/plugins-release/org/codehaus/groovy/groovy-eclipse-compiler
+      FIXME:    https://groovy.jfrog.io/artifactory/plugins-release/org/codehaus/groovy/groovy-eclipse-batch
+
+      FIXME: asked why here: https://github.com/groovy/groovy-eclipse/issues/1416
+      -->
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
         <dependencies>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-eclipse-compiler</artifactId>
-            <version>3.7.0</version>
+            <version>3.8.0</version>
           </dependency>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-eclipse-batch</artifactId>
-            <version>3.0.8-01</version>
+            <version>4.0.6-02</version>
           </dependency>
         </dependencies>
         <configuration>
-          <!-- see: https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin -->
           <compilerId>groovy-eclipse-compiler</compilerId>
         </configuration>
       </plugin>

--- a/support/pom.xml
+++ b/support/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy</artifactId>
       <optional>true</optional>
     </dependency>

--- a/testbase/pom.xml
+++ b/testbase/pom.xml
@@ -66,12 +66,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-ant</artifactId>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Unfortunately; the latest builds of the compiler and batch adapter are not published to Maven Central.

https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#how-to-use-the-compiler-plugin---setting-up-the-pom

They are only in:
* https://groovy.jfrog.io/artifactory/plugins-release/org/codehaus/groovy/groovy-eclipse-compiler
* https://groovy.jfrog.io/artifactory/plugins-release/org/codehaus/groovy/groovy-eclipse-batch

Asked why here: https://github.com/groovy/groovy-eclipse/issues/1416